### PR TITLE
updated no-unused-vars rule to allow for arg/param deconstructs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,40 +1,41 @@
 module.exports = {
-    extends: [
-      'eslint:recommended',
-      'plugin:react/recommended',
-      'plugin:import/recommended',
-      'standard'
-    ],
-    parser: 'babel-eslint',
-    parserOptions: {
-      ecmaVersion: 10
-    },
-    env: {
-      es6: true,
-      browser: true,
-      mocha: true,
-      node: true,
-      jest: true
-    },
-    settings: {
-        react: {
-            version: '16.0'
-        },
-        'import/resolver': {
-            node: {
-              paths: ['./src']
-            }
-        }
-    },
-    plugins: [
-      'react',
-      'react-hooks',
-      'jsdoc',
-      'jsx-a11y'
-    ],
-    rules: {
-      'node/no-deprecated-api': 1,
-      'curly': [2, 'multi', 'consistent'],
-      'react-hooks/rules-of-hooks': 'error'
-    }
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:import/recommended',
+    'standard'
+  ],
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 10
+  },
+  env: {
+    es6: true,
+    browser: true,
+    mocha: true,
+    node: true,
+    jest: true
+  },
+  settings: {
+      react: {
+          version: '16.0'
+      },
+      'import/resolver': {
+          node: {
+            paths: ['./src']
+          }
+      }
+  },
+  plugins: [
+    'react',
+    'react-hooks',
+    'jsdoc',
+    'jsx-a11y'
+  ],
+  rules: {
+    'node/no-deprecated-api': 1,
+    'curly': [2, 'multi', 'consistent'],
+    'react-hooks/rules-of-hooks': 'error',
+    'no-unused-vars': [2, { 'ignoreRestSiblings': false }]
   }
+}


### PR DESCRIPTION
Sets the `ignoreRestSiblings` option on `no-unused-vars` to be `false`. 

This means that we can get the correct `no-unused-vars` error to appear for deconstructed function parameters.

For example, given:
```
const someFunction = ({  a, b, c }) => {
  return [a, c]
}
```
will result in:
`'b' is defined but never used.`

This also prevents the use of a `...rest` from messing with this error.
```
const someFunction = ({  a, b, c, ...rest }) => {
  return [a, c, rest]
}
```
will still result in:
`'b' is defined but never used.`
