### PR TITLE
Add in comma dangle rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
   ],
   rules: {
     'node/no-deprecated-api': 1,
-    'comma-dangle' : [1, 'always-multiline'],
+    'comma-dangle' : [2, 'always-multiline'],
     'curly': [2, 'multi-line', 'consistent'],
     'react-hooks/rules-of-hooks': 'error',
     'no-unused-vars': [2, { 'ignoreRestSiblings': false }]


### PR DESCRIPTION
This is a proposal to add a rule which Front End has suggested be part of the 15gifts rules.

We recently removed most of our rules to use this repo instead, with the comma dangle being one of the biggest changes to Leap2.

Having all of us work with this new rule for a few weeks, we have decided we prefer the previous setting and propose making this part of our global es lint rules. We have agreed to add this back into Leap2, and have a PR ready to merge with the rule change and lint fixes included.

Our reasons for this is that during Pull requests, it marks extra lines as being edited, even though an extra comma has only been added to the previous line. This just adds extra checks to the code which are a little unnecessary.

It also causes issues with general coding flow where, before adding new lines or moving lines, linting errors arise where a comma has been missed. Having the comma dangle makes it easier and quicker to just add lines to the end or an object or array.

ES lint can easily add a new comma to the end on save. But a missing one in the object requires developer action.