### PR TITLE
Adding Stroustrup brace styles

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     'node/no-deprecated-api': 1,
     'curly': [2, 'multi-line', 'consistent'],
     'react-hooks/rules-of-hooks': 'error',
-    'no-unused-vars': [2, { 'ignoreRestSiblings': false }]
+    'no-unused-vars': [2, { 'ignoreRestSiblings': false }],
+    'brace-style': ['error', 'stroustrup'],
   }
 }


### PR DESCRIPTION
I would like to suggest to switch to the brace style where `else` and `catch` are on their own line, ie.

```javascript
if (foo) {
  bar()
}
else {
  baz()
}

try {
  somethingRisky()
}
catch(e) {
  handleError()
}
```

The main reason why I prefer it is that I can work with each `if`, `else`, `try` and `catch` block separately. If an `else` block contains a lot of code, I can easily separate it with a few blank lines from the previous `if` block and add a comment on top of it like so:

```javascript
if (foo) {
  bar()
}

// this else is really cool, we should do more else's like this
else {
  baz()
}

```

I find it impossible to do the same when we use `} else {`.