### PR TITLE
Add in sort destructure keys plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,14 +30,16 @@ module.exports = {
     'react',
     'react-hooks',
     'jsdoc',
-    'jsx-a11y'
+    'jsx-a11y',
+    'sort-destructure-keys'
   ],
   rules: {
-    'node/no-deprecated-api': 1,
+    'brace-style': ['error', 'stroustrup'],
     'comma-dangle' : [2, 'always-multiline'],
     'curly': [2, 'multi-line', 'consistent'],
-    'react-hooks/rules-of-hooks': 'error',
     'no-unused-vars': [2, { 'ignoreRestSiblings': false }],
-    'brace-style': ['error', 'stroustrup'],
+    'node/no-deprecated-api': 1,
+    'react-hooks/rules-of-hooks': 'error',
+    'sort-destructure-keys/sort-destructure-keys': 2
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^1.5.0",
+    "eslint-plugin-sort-destructure-keys": "^1.3.3",
     "eslint-plugin-standard": "^4.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Forces destructured variables to be in alphabetical order to help with tidiness. 